### PR TITLE
Fix PHP 8.4 deprecation notice

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-function nestable(array $data = null)
+function nestable(?array $data = null)
 {
     $nestable = \App::make('Nestable\Services\NestableService');
 


### PR DESCRIPTION
Fix "Implicitly nullable parameter declarations deprecated" raised under PHP 8.4, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated